### PR TITLE
2 small changes to your code to make it behave more like PhoneGap: Media.play(), touchmove

### DIFF
--- a/js/phonegap-desktop.js
+++ b/js/phonegap-desktop.js
@@ -666,6 +666,7 @@ function Media(src, mediaSuccess, mediaError, mediaStatus){
     this.ErrorCallback = mediaError;
     this.StatusCallback = mediaStatus;
     var audioObj = new Audio(src);
+    audioObj.addEventListener("ended", this.SuccessCallback);
 	audioObj.load();
     var that = this;
     
@@ -695,7 +696,6 @@ function Media(src, mediaSuccess, mediaError, mediaStatus){
 			else {
 		        phonegapdesktop.utility.timedPopup(35, 90, 60, 5, "Unsupported audio: " + (src.substr(src.lastIndexOf('.')) || src), 1000, "DarkBlue");
 			}
-            that.SuccessCallback();
         }
     };
     this.pause = function(){

--- a/js/phonegap-desktop.js
+++ b/js/phonegap-desktop.js
@@ -11,7 +11,6 @@ window.addEventListener('load', function(){
         document.onmousedown = function(e){
             phonegapdesktop.internal.dispatchTouchEvent(e, "touchstart");
             phonegapdesktop.internal.touchActive = true;
-            phonegapdesktop.internal.dispatchTouchEvent(e, "touchmove");
         };
         
         document.onmousemove = function(e){
@@ -21,7 +20,6 @@ window.addEventListener('load', function(){
         };
         
         document.onmouseup = function(e){
-            phonegapdesktop.internal.dispatchTouchEvent(e, "touchmove");
             phonegapdesktop.internal.touchActive = false;
             phonegapdesktop.internal.dispatchTouchEvent(e, "touchend");
         };


### PR DESCRIPTION
1. when I called Media.play() it immediately called the success callback. Now it only calls when play finished.
2. touchmove was called by both mousedown, mouseup, hovever in PhoneGap they're different: you can touch, release (basically it's a click) without moving your finger. I have code that behaves differently when I swipe and when I click, so this fix was needed to make it work.
